### PR TITLE
Add ability to edit tasks

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -168,6 +168,19 @@ Format: `deletetask INDEX`
 Examples:
 * `listtask` followed by `deletetask 2` deletes the 2nd person in the application.
 
+### Editing a task : `edittask`
+
+Edits an existing task in the application.
+
+Format: `edittask INDEX l/LABEL d/DATE`
+
+* Edits the task at the specified `INDEX`. The index refers to the index number shown in the displayed task list. The index **must be a positive integer** 1, 2, 3, …​
+* At least one of the optional fields must be provided.
+* Existing values will be updated to the input values.
+
+Examples:
+*  `edittask 1 l/order cloth d/19th September 2021` Edits the label and date of the 1st task to be `order cloth` and `19th September 2021` respectively.
+
 ### Mark a task as done: `markdone`
 
 Marks a specified task from the application as complete.
@@ -204,5 +217,6 @@ Action | Format, Examples
 **ListTask** | `listtask`
 **AddTask** | `addtask l/LABEL d/DATE` e.g. `addtask l/sew buttons onto blazer d/20th August 2021`
 **DeleteTask** | `deletetask INDEX` e.g. `deletetask 1`
+**EditTask** | `edittask INDEX l/LABEL d/DATE` e.g. `edittask 1 l/order cloth d/19th September 2021`
 **MarkDone** | `markdone INDEX` e.g. `markdone 2`
 

--- a/src/main/java/seedu/address/logic/commands/EditTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditTaskCommand.java
@@ -1,0 +1,173 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LABEL;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_TASKS;
+
+import java.util.List;
+import java.util.Optional;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.task.Date;
+import seedu.address.model.task.Label;
+import seedu.address.model.task.Task;
+
+/**
+ * Edits the details of an existing task in the address book.
+ */
+public class EditTaskCommand extends Command {
+
+    public static final String COMMAND_WORD = "edittask";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the task identified "
+            + "by the index number used in the displayed task list. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[" + PREFIX_LABEL + "LABEL] "
+            + "[" + PREFIX_DATE + "DATE]...\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_LABEL + "Order cloth "
+            + PREFIX_DATE + "19th September 2021";
+
+    public static final String MESSAGE_EDIT_TASK_SUCCESS = "Edited Task: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_TASK = "This task already exists in the task list.";
+    public static final String MESSAGE_NO_CHANGES_MADE = "You haven't made any changes to the task.";
+
+    private final Index index;
+    private final EditTaskDescriptor editTaskDescriptor;
+
+    /**
+     * @param index of the task in the filtered task list to edit
+     * @param editTaskDescriptor details to edit the task with
+     */
+    public EditTaskCommand(Index index, EditTaskDescriptor editTaskDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editTaskDescriptor);
+
+        this.index = index;
+        this.editTaskDescriptor = new EditTaskDescriptor(editTaskDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Task> lastShownList = model.getFilteredTaskList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+        }
+
+        Task taskToEdit = lastShownList.get(index.getZeroBased());
+        Task editedTask = createEditedTask(taskToEdit, editTaskDescriptor);
+
+        if (taskToEdit.equals(editedTask)) {
+            throw new CommandException(MESSAGE_NO_CHANGES_MADE);
+        }
+
+        if (!taskToEdit.equals(editedTask) && model.hasTask(editedTask)) {
+            throw new CommandException(MESSAGE_DUPLICATE_TASK);
+        }
+
+        model.setTask(taskToEdit, editedTask);
+        model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
+        return new CommandResult(String.format(MESSAGE_EDIT_TASK_SUCCESS, editedTask));
+    }
+
+    /**
+     * Creates and returns a {@code Task} with the details of {@code taskToEdit}
+     * edited with {@code editTaskDescriptor}.
+     */
+    private static Task createEditedTask(Task taskToEdit, EditTaskDescriptor editTaskDescriptor) {
+        assert taskToEdit != null;
+
+        Label updatedLabel = editTaskDescriptor.getLabel().orElse(taskToEdit.getLabel());
+        Date updatedDate = editTaskDescriptor.getDate().orElse(taskToEdit.getDate());
+
+        return new Task(updatedLabel, updatedDate);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditTaskCommand)) {
+            return false;
+        }
+
+        // state check
+        EditTaskCommand e = (EditTaskCommand) other;
+        return index.equals(e.index)
+                && editTaskDescriptor.equals(e.editTaskDescriptor);
+    }
+
+    /**
+     * Stores the details to edit the task with. Each non-empty field value will replace the
+     * corresponding field value of the task.
+     */
+    public static class EditTaskDescriptor {
+        private Date date;
+        private Label label;
+
+        public EditTaskDescriptor() {}
+
+        /**
+         * Copy constructor.
+         */
+        public EditTaskDescriptor(EditTaskDescriptor toCopy) {
+            setDate(toCopy.date);
+            setLabel(toCopy.label);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(date, label);
+        }
+
+        public void setDate(Date date) {
+            this.date = date;
+        }
+
+        public Optional<Date> getDate() {
+            return Optional.ofNullable(date);
+        }
+
+        public void setLabel(Label label) {
+            this.label = label;
+        }
+
+        public Optional<Label> getLabel() {
+            return Optional.ofNullable(label);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditTaskDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditTaskDescriptor e = (EditTaskDescriptor) other;
+
+            return getLabel().equals(e.getLabel())
+                    && getDate().equals(e.getDate());
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteTaskCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditTaskCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -74,6 +75,9 @@ public class AddressBookParser {
 
         case AddTaskCommand.COMMAND_WORD:
             return new AddTaskCommandParser().parse(arguments);
+
+        case EditTaskCommand.COMMAND_WORD:
+            return new EditTaskCommandParser().parse(arguments);
 
         case DeleteTaskCommand.COMMAND_WORD:
             return new DeleteTaskCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/EditTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditTaskCommandParser.java
@@ -1,0 +1,51 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LABEL;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditTaskCommand;
+import seedu.address.logic.commands.EditTaskCommand.EditTaskDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditTaskCommand object
+ */
+public class EditTaskCommandParser implements Parser<EditTaskCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditTaskCommand
+     * and returns an EditTaskCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditTaskCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_LABEL, PREFIX_DATE);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditTaskCommand.MESSAGE_USAGE), pe);
+        }
+
+        EditTaskDescriptor editTaskDescriptor = new EditTaskDescriptor();
+        if (argMultimap.getValue(PREFIX_LABEL).isPresent()) {
+            editTaskDescriptor.setLabel(ParserUtil.parseLabel(argMultimap.getValue(PREFIX_LABEL).get()));
+        }
+        if (argMultimap.getValue(PREFIX_DATE).isPresent()) {
+            editTaskDescriptor.setDate(ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get()));
+        }
+
+        if (!editTaskDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditTaskCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditTaskCommand(index, editTaskDescriptor);
+    }
+
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -78,18 +78,6 @@ public interface Model {
      */
     void setPerson(Person target, Person editedPerson);
 
-    /**
-     * Returns true if a task with the same identity as {@code task} exists in the task list.
-     */
-    boolean hasTask(Task task);
-
-    /**
-     * Replaces the given task {@code target} with {@code editedTask}.
-     * {@code target} must exist in the task list.
-     * The task identity of {@code editedTask} must not be the same as another existing task in the address book.
-     */
-    void setTask(Task target, Task editedTask);
-
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 
@@ -104,6 +92,18 @@ public interface Model {
      * Adds the given task.
      */
     void addTask(Task task);
+
+    /**
+     * Returns true if a task with the same identity as {@code task} exists in the task list.
+     */
+    boolean hasTask(Task task);
+
+    /**
+     * Replaces the given task {@code target} with {@code editedTask}.
+     * {@code target} must exist in the task list.
+     * The task identity of {@code editedTask} must not be the same as another existing task in the task list.
+     */
+    void setTask(Task target, Task editedTask);
 
     /** Returns and unmodifiable view of the filtered task list */
     //added prior to the ui functionality actually being implemented.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -78,6 +78,18 @@ public interface Model {
      */
     void setPerson(Person target, Person editedPerson);
 
+    /**
+     * Returns true if a task with the same identity as {@code task} exists in the task list.
+     */
+    boolean hasTask(Task task);
+
+    /**
+     * Replaces the given task {@code target} with {@code editedTask}.
+     * {@code target} must exist in the task list.
+     * The task identity of {@code editedTask} must not be the same as another existing task in the address book.
+     */
+    void setTask(Task target, Task editedTask);
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -120,12 +120,25 @@ public class ModelManager implements Model {
 
     //=========== Task Management ==================================================================================
 
+    @Override
+    public boolean hasTask(Task task) {
+        requireNonNull(task);
+        return tasks.hasTask(task);
+    }
+
     public void addTask(Task toAdd) {
         tasks.add(toAdd);
     }
 
     public void deleteTask(Task toDelete) {
         tasks.remove(toDelete);
+    }
+
+    @Override
+    public void setTask(Task target, Task editedTask) {
+        requireAllNonNull(target, editedTask);
+
+        tasks.setTask(target, editedTask);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/TaskList.java
+++ b/src/main/java/seedu/address/model/task/TaskList.java
@@ -1,11 +1,14 @@
 package seedu.address.model.task;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
 import seedu.address.model.task.exceptions.TaskNotFoundException;
 
 /**
@@ -17,6 +20,15 @@ public class TaskList implements Iterable<Task> {
     private final ObservableList<Task> internalList = FXCollections.observableArrayList();
     private final ObservableList<Task> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);
+
+
+    /**
+     * Returns true if a task with the same identity as {@code task} exists in the task list.
+     */
+    public boolean hasTask(Task task) {
+        requireNonNull(task);
+        return internalList.stream().anyMatch(task::equals);
+    }
 
     /**
      * Adds a task to the list.
@@ -36,12 +48,33 @@ public class TaskList implements Iterable<Task> {
         }
     }
 
+
+    /**
+     * Replaces the given task {@code target} in the list with {@code editedTask}.
+     * {@code target} must exist in the task list.
+     * The task identity of {@code editedTask} must not be the same as another existing task in the task list.
+     */
+    public void setTask(Task target, Task editedTask) {
+        requireAllNonNull(target, editedTask);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new PersonNotFoundException();
+        }
+
+        if (!target.equals(editedTask) && hasTask(editedTask)) {
+            throw new DuplicatePersonException();
+        }
+
+        internalList.set(index, editedTask);
+    }
+
     /**
      * Marks a task as done.
      */
     public void markDone(Task toMark) {
         requireNonNull(toMark);
-        if (!internalList.contains(toMark)) {
+        if (!hasTask(toMark)) {
             throw new TaskNotFoundException();
         }
         int index = internalList.indexOf(toMark);

--- a/src/test/java/seedu/address/ModelStub.java
+++ b/src/test/java/seedu/address/ModelStub.java
@@ -76,6 +76,16 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public boolean hasTask(Task task) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setTask(Task target, Task editedTask) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public ObservableList<Person> getFilteredPersonList() {
         throw new AssertionError("This method should not be called.");
     }


### PR DESCRIPTION
Added the edit task functionality.  Added the `hasTask`, `setTask` methods to the model.

The implementation is similar to that of the edit person feature, with another constraint - the edited task cannot be identical to the original task. This is allowed in the edit person command.

Tasks are considered identical only when both their dates and labels match. This is different from the Person class, where only the name needs to match.


