### PR TITLE
Format totalorders amount

### DIFF
--- a/src/main/java/seedu/address/ui/TotalOrdersWindow.java
+++ b/src/main/java/seedu/address/ui/TotalOrdersWindow.java
@@ -8,7 +8,6 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.stage.Stage;
-import javafx.util.Callback;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
 import seedu.address.model.ClientTotalOrder;

--- a/src/main/java/seedu/address/ui/TotalOrdersWindow.java
+++ b/src/main/java/seedu/address/ui/TotalOrdersWindow.java
@@ -3,10 +3,12 @@ package seedu.address.ui;
 import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
+import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.stage.Stage;
+import javafx.util.Callback;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
 import seedu.address.model.ClientTotalOrder;
@@ -33,6 +35,7 @@ public class TotalOrdersWindow extends UiPart<Stage> {
     public TotalOrdersWindow(Logic logic) {
         super(FXML, new Stage());
         this.logic = logic;
+        formatTotalColumn();
     }
 
     /**
@@ -87,5 +90,22 @@ public class TotalOrdersWindow extends UiPart<Stage> {
         table.setItems(logic.getClientTotalOrders());
         clientCol.setCellValueFactory(new PropertyValueFactory<>("clientName"));
         totalCol.setCellValueFactory(new PropertyValueFactory<>("totalOrder"));
+    }
+
+    /**
+     * Formats the total column to always display amount with 2 decimal places.
+     */
+    private void formatTotalColumn() {
+        totalCol.setCellFactory(tc -> new TableCell<>() {
+            @Override
+            protected void updateItem(Double value, boolean empty) {
+                super.updateItem(value, empty);
+                if (empty) {
+                    setText(null);
+                } else {
+                    setText(String.format("%.2f", value));
+                }
+            }
+        });
     }
 }

--- a/src/main/java/seedu/address/ui/TotalOrdersWindow.java
+++ b/src/main/java/seedu/address/ui/TotalOrdersWindow.java
@@ -103,7 +103,7 @@ public class TotalOrdersWindow extends UiPart<Stage> {
                 if (empty) {
                     setText(null);
                 } else {
-                    setText(String.format("%.2f", value));
+                    setText(String.format("%.2f ", value));
                 }
             }
         });

--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -20,5 +20,5 @@
 }
 
 #totalCol {
-    -fx-alignment: CENTER;
+    -fx-alignment: CENTER-RIGHT;
 }

--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -18,3 +18,7 @@
 .tooltip-text {
     -fx-text-fill: white;
 }
+
+#totalCol {
+    -fx-alignment: CENTER;
+}

--- a/src/main/resources/view/TotalOrdersWindow.fxml
+++ b/src/main/resources/view/TotalOrdersWindow.fxml
@@ -17,6 +17,7 @@
     <Scene>
       <stylesheets>
         <URL value="@Fonts.css" />
+        <URL value="@Extensions.css"/>
       </stylesheets>
 
       <HBox alignment="CENTER">


### PR DESCRIPTION
Format amount to always show two decimal places and align right
![image](https://user-images.githubusercontent.com/19379090/138595328-a0a2573c-a910-44e7-b116-e739b067b1b8.png)

Note that there is deep nesting in the `formatTotalColumn` method in the `TotalOrdersWindow` class, but I am unable to find any way to flatten the nesting.