### PR TITLE
Update findorder command

### DIFF
--- a/src/main/java/seedu/address/model/order/OrderContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/order/OrderContainsKeywordsPredicate.java
@@ -25,7 +25,7 @@ public class OrderContainsKeywordsPredicate implements Predicate<Order> {
                 || keywords.stream()
                         .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(order.getCustomer().name, keyword))
                 || keywords.stream()
-                        .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(String.valueOf(order.getId()), keyword));
+                        .anyMatch(keyword -> StringUtil.containsWordIgnoreCase("SO" + order.getId(), keyword));
     }
 
     @Override


### PR DESCRIPTION
* before: to search an order with id SO6, we only can do it by inputting findorder '6' (not 'SO6')