### PR TITLE
Update MarkOrderCommand when order already marked

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkOrderCommand.java
@@ -24,6 +24,8 @@ public class MarkOrderCommand extends Command {
 
     public static final String MESSAGE_MARK_ORDER_SUCCESS = "Marked Order: %1$s";
 
+    public static final String MESSAGE_ORDER_ALREADY_MARKED = "Order already marked: %1$s";
+
     private final Index targetIndex;
 
     public MarkOrderCommand(Index targetIndex) {
@@ -40,9 +42,16 @@ public class MarkOrderCommand extends Command {
         }
 
         Order orderToMark = lastShownList.get(targetIndex.getZeroBased());
-        model.markOrder(orderToMark);
-        return new CommandResult(String.format(MESSAGE_MARK_ORDER_SUCCESS, orderToMark),
-                CommandResult.DisplayState.ORDER);
+
+        boolean hasChanged = model.markOrder(orderToMark);
+        if (hasChanged) {
+            return new CommandResult(String.format(MESSAGE_MARK_ORDER_SUCCESS, orderToMark),
+                    CommandResult.DisplayState.ORDER);
+        } else {
+            return new CommandResult(String.format(MESSAGE_ORDER_ALREADY_MARKED, orderToMark),
+                    CommandResult.DisplayState.ORDER);
+        }
+
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -198,7 +198,7 @@ public interface Model {
 
     void updateFilteredOrderList(Predicate<Order> predicate);
 
-    void markOrder(Order order);
+    boolean markOrder(Order order);
 
     void sortOrderList(SortDescriptor sortDescriptor);
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -22,6 +22,7 @@ import seedu.address.model.task.Task;
  * Represents the in-memory model of the address book data.
  */
 public class ModelManager implements Model {
+
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
     private final AddressBook addressBook;
@@ -287,8 +288,8 @@ public class ModelManager implements Model {
     /**
      * Marks an order as completed
      */
-    public void markOrder(Order order) {
-        orderBook.markOrder(order);
+    public boolean markOrder(Order order) {
+        return orderBook.markOrder(order);
     }
 
     /**

--- a/src/main/java/seedu/address/model/OrderBook.java
+++ b/src/main/java/seedu/address/model/OrderBook.java
@@ -69,8 +69,8 @@ public class OrderBook implements ReadOnlyOrderBook {
         orders.remove(toDelete);
     }
 
-    public void markOrder(Order order) {
-        orders.markComplete(order);
+    public boolean markOrder(Order order) {
+        return orders.markComplete(order);
     }
 
     public void setOrder(Order target, Order editedOrder) {

--- a/src/main/java/seedu/address/model/order/Order.java
+++ b/src/main/java/seedu/address/model/order/Order.java
@@ -4,6 +4,7 @@ import seedu.address.model.Date;
 import seedu.address.model.Label;
 
 public class Order implements Comparable<Order> {
+
     private static final String idPrefix = "SO";
     private static int count = 1;
 
@@ -33,8 +34,17 @@ public class Order implements Comparable<Order> {
         return this.isComplete;
     }
 
-    public void setIsComplete(boolean isComplete) {
-        this.isComplete = isComplete;
+    /**
+     * Mark an order as completed by setting isComplete to true.
+     * @return boolean indicating whether isComplete has been changed or not.
+     */
+    public boolean markCompleted() {
+        if (this.isComplete == true) {
+            return false;
+        } else {
+            this.isComplete = true;
+            return true;
+        }
     }
 
     public Amount getAmount() {

--- a/src/main/java/seedu/address/model/order/OrderList.java
+++ b/src/main/java/seedu/address/model/order/OrderList.java
@@ -18,6 +18,7 @@ import seedu.address.model.order.exceptions.OrderNotFoundException;
  * Basic version does not support editing SalesOrders.
  */
 public class OrderList implements Iterable<Order> {
+
     private final ObservableList<Order> internalList = FXCollections.observableArrayList();
     private final ObservableList<Order> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);
@@ -86,17 +87,19 @@ public class OrderList implements Iterable<Order> {
     }
 
     /**
-     * Marks an order as complete, if it exists in the OrderList
+     * Marks an order as complete, if it exists in the OrderList. Returns a boolean indicating
+     * whether or not an actual change has been made.
      * @param toMark
      */
-    public void markComplete(Order toMark) {
+    public boolean markComplete(Order toMark) {
         requireNonNull(toMark);
         if (!hasOrder(toMark)) {
             throw new OrderNotFoundException();
         }
         int index = internalList.indexOf(toMark);
-        toMark.setIsComplete(true);
+        boolean hasChanged = toMark.markCompleted();
         internalList.set(index, toMark);
+        return hasChanged;
     }
 
     public ObservableList<Order> asUnmodifiableObservableList() {

--- a/src/main/java/seedu/address/storage/JsonAdaptedOrder.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedOrder.java
@@ -104,9 +104,9 @@ class JsonAdaptedOrder {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "isComplete"));
         }
         if (isComplete.equals("true")) {
-            newOrder.setIsComplete(true);
+            newOrder.markCompleted();
         } else if (isComplete.equals("false")) {
-            newOrder.setIsComplete(false);
+            // intentionally allow fall through
         } else {
             throw new IllegalValueException("Something is wrong");
         }

--- a/src/test/java/seedu/address/ModelStub.java
+++ b/src/test/java/seedu/address/ModelStub.java
@@ -166,7 +166,7 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public void markOrder(Order order) {
+    public boolean markOrder(Order order) {
         throw new AssertionError("This method should not be called.");
     }
 

--- a/src/test/java/seedu/address/logic/commands/MarkOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkOrderCommandTest.java
@@ -17,6 +17,7 @@ import seedu.address.model.order.Order;
 import seedu.address.testutil.OrderBuilder;
 
 class MarkOrderCommandTest {
+
     private static final Order testOrder = new OrderBuilder().build();
 
     @Test
@@ -43,12 +44,25 @@ class MarkOrderCommandTest {
 
     }
 
+    @Test
+    public void execute_markAlreadyCompleted_notification() throws Exception {
+        Index targetIndex = Index.fromOneBased(1);
+        ModelStubWithOneOrder modelStub = new ModelStubWithOneOrder();
+
+        // mark the order twice, verify that notification is given.
+        new MarkOrderCommand(targetIndex).execute(modelStub);
+        CommandResult commandResult = new MarkOrderCommand(targetIndex).execute(modelStub);
+
+        assertEquals(String.format(MarkOrderCommand.MESSAGE_ORDER_ALREADY_MARKED, testOrder),
+                commandResult.getFeedbackToUser());
+    }
+
     private class ModelStubWithOneOrder extends ModelStub {
         private final ObservableList<Order> listWithOneOrder = FXCollections.observableArrayList(testOrder);
 
         @Override
-        public void markOrder(Order order) {
-            listWithOneOrder.get(0).setIsComplete(true);
+        public boolean markOrder(Order order) {
+            return listWithOneOrder.get(0).markCompleted();
         }
 
         @Override

--- a/src/test/java/seedu/address/testutil/OrderBuilder.java
+++ b/src/test/java/seedu/address/testutil/OrderBuilder.java
@@ -35,7 +35,7 @@ public class OrderBuilder {
     }
 
     /**
-     * Initializes the OrderBuilder with the data of {@code orderToCopyd}.
+     * Initializes the OrderBuilder with the data of {@code orderToCopy}.
      */
     public OrderBuilder(Order orderToCopy) {
         label = orderToCopy.getLabel();
@@ -83,8 +83,10 @@ public class OrderBuilder {
      */
     public Order build() {
         Order order = new Order(label, customer, date, amount);
-        order.setIsComplete(isComplete);
         order.setId(this.id);
+        if (this.isComplete) {
+            order.markCompleted();
+        }
         return order;
     }
 }


### PR DESCRIPTION
* If attempting to mark an order that was already completed,
a new message is given to the user.
* Have changed the function from setIsComplete() to markComplete(),
since we do not allow undo of completion. The function will return
a boolean hasChanged informing the caller whether or not there
was a change made to the orders completed status.
* Testcases were updated
* Resolves #220 